### PR TITLE
Fix content selector import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {ViewCompiler,CompositionEngine,ViewResources,ViewSlot,ViewEngine, ResourceRegistry , Container} from 'aurelia-framework';
 import {DefaultLoader} from 'aurelia-loader-default';
 import {TemplateRegistryEntry} from 'aurelia-loader';
-import {ContentSelector} from 'aurelia-templating/content-selector';
+import {ContentSelector} from 'aurelia-templating';
 
 /**
  * Compiler service


### PR DESCRIPTION
Content selector import is broken in release 0.0.5 as Aurelia components are all bundled into one module now